### PR TITLE
Add ntpshmmon to Package/gpsd-clients/install

### DIFF
--- a/utils/gpsd/Makefile
+++ b/utils/gpsd/Makefile
@@ -130,6 +130,7 @@ define Package/gpsd-clients/install
 		$(PKG_INSTALL_DIR)/usr/bin/gps{ctl,decode,mon,pipe} \
 		$(PKG_INSTALL_DIR)/usr/bin/gpxlogger \
 		$(PKG_INSTALL_DIR)/usr/bin/lcdgps \
+		$(PKG_INSTALL_DIR)/usr/bin/ntpshmmon \
 		$(1)/usr/bin/
 endef
 


### PR DESCRIPTION
gpsd on routers is typically used to discipline the clock via ntpd/chrony.
Signed-off-by: Avinash Duduskar <strykar@hotmail.com>

Maintainer: @psidhu
Compile tested: x86/64, apu2, OpenWrt SNAPSHOT r8630-4fd7882, 4.14.82
Run tested:
```
root@apu:~# ntpshmmon 
ntpshmmon version 1
#      Name Seen@                Clock                Real                 L Prec
sample NTP1 1543974486.000627123 1543974485.999995486 1543974486.000000000 0 -30
sample NTP0 1543974486.102723510 1543974486.102485827 1543974486.000000000 0 -20
sample NTP1 1543974487.000298096 1543974486.999995980 1543974487.000000000 0 -30
sample NTP0 1543974487.105579850 1543974487.104527262 1543974487.000000000 0 -20
sample NTP1 1543974488.000697526 1543974487.999991080 1543974488.000000000 0 -30
sample NTP0 1543974488.106144547 1543974488.106008184 1543974488.000000000 0 -20
^Z[2]+  Stopped                    ntpshmmon
```

Description:
Build the ntpshmmon binary to verify if gpsd can share memory segments.